### PR TITLE
fix: "Requested format is not available" error on URL input

### DIFF
--- a/Macabolic/Services/YtdlpService.swift
+++ b/Macabolic/Services/YtdlpService.swift
@@ -200,7 +200,9 @@ class YtdlpService: ObservableObject {
             path,
             "--dump-json",
             "--no-playlist",
-            "--no-warnings"
+            "--no-warnings",
+            "-f",
+            "bestvideo+bestaudio/best"
         ]
         
         appendCookieArgs(to: &args)


### PR DESCRIPTION
## Fix for #13

### Problem
When pasting a YouTube URL, Macabolic immediately throws:
```
ERROR: [youtube] <id>: Requested format is not available.
Use --list-formats for a list of available formats
```
The format/quality selection UI never appears and the download never starts.

### Root Cause
`fetchSingleVideoInfo()` calls `yt-dlp --dump-json` without an explicit `-f` format flag. 
Without it, yt-dlp uses its internal default format selector which can fail on certain 
videos before any metadata is returned. This kills the flow before the user ever sees 
the format picker.

### Fix
Add `-f bestvideo+bestaudio/best` to the `--dump-json` call in `fetchSingleVideoInfo()`. 
This gives yt-dlp a permissive format to resolve during info fetching, ensuring metadata 
is always returned so the user can proceed to format selection.

### Testing
- Built and launched locally in Debug configuration
- Tested with URLs from the original issue (#13)
- Verified format selection UI appears correctly after pasting a YouTube URL